### PR TITLE
Allow Static Membership assignment

### DIFF
--- a/docs/includes/settingref.txt
+++ b/docs/includes/settingref.txt
@@ -1018,6 +1018,25 @@ exists, e.g. when starting a new consumer for the first time.
 Options include 'earliest', 'latest', 'none'.
 
 
+.. setting:: consumer_group_instance_id
+
+``consumer_group_instance_id``
+------------------------------
+
+.. versionadded:: 2.1
+
+:type: :class:`str`
+:default: :const:`None`
+:environment: :envvar:`CONSUMER_GROUP_INSTANCE_ID`
+
+Consumer group instance id.
+
+The group_instance_id for static partition assignment.
+
+If not set, default assignment strategy is used. Otherwise,
+each consumer instance has to have a unique id.
+
+
 .. setting:: ConsumerScheduler
 
 ``ConsumerScheduler``

--- a/faust/transport/drivers/aiokafka.py
+++ b/faust/transport/drivers/aiokafka.py
@@ -345,6 +345,7 @@ class AIOKafkaConsumerThread(ConsumerThread):
             api_version=conf.consumer_api_version,
             client_id=conf.broker_client_id,
             group_id=conf.id,
+            group_instance_id=conf.consumer_group_instance_id,
             bootstrap_servers=server_list(
                 transport.url, transport.default_port),
             partition_assignment_strategy=[self._assignor],

--- a/faust/types/settings/settings.py
+++ b/faust/types/settings/settings.py
@@ -109,6 +109,7 @@ class Settings(base.SettingsRegistry):
             consumer_api_version: str = None,
             consumer_max_fetch_size: int = None,
             consumer_auto_offset_reset: str = None,
+            consumer_group_instance_id: str = None,
             # Topic serialization settings:
             key_serializer: CodecArg = None,
             value_serializer: CodecArg = None,
@@ -1097,6 +1098,21 @@ class Settings(base.SettingsRegistry):
         exists, e.g. when starting a new consumer for the first time.
 
         Options include 'earliest', 'latest', 'none'.
+        """
+
+    @sections.Consumer.setting(
+        params.Str,
+        version_introduced='2.1',
+        env_name='CONSUMER_GROUP_INSTANCE_ID',
+        default=None,
+    )
+    def consumer_group_instance_id(self) -> str:
+        """Consumer group instance id.
+
+        The group_instance_id for static partition assignment.
+
+        If not set, default assignment strategy is used. Otherwise,
+        each consumer instance has to have a unique id.
         """
 
     @sections.Serialization.setting(

--- a/t/unit/transport/drivers/test_aiokafka.py
+++ b/t/unit/transport/drivers/test_aiokafka.py
@@ -737,6 +737,7 @@ class test_AIOKafkaConsumerThread(AIOKafkaConsumerThreadFixtures):
                 api_version=app.conf.consumer_api_version,
                 client_id=conf.broker_client_id,
                 group_id=conf.id,
+                group_instance_id=conf.consumer_group_instance_id,
                 bootstrap_servers=server_list(
                     transport.url, transport.default_port),
                 partition_assignment_strategy=[cthread._assignor],


### PR DESCRIPTION
Depends on aiokafka pull-request robinhood/aiokafka#21

Adds consumer_group_instance_id setting to enable static membership protocol.
If enabled, a reset of one node (e.g. update) does not trigger a rebalance of the whole group, if the resetted node comes up again within broker_session_timeout. The node will get its previous assignment and return to work, while other nodes are not interrupted.